### PR TITLE
feat: add localstorage and clearList and show modal iteam buttons to ListManager

### DIFF
--- a/src/core/ListManagerCore.ts
+++ b/src/core/ListManagerCore.ts
@@ -1,16 +1,45 @@
 import { v4 as uuidv4 } from "uuid";
 
 export class ListManagerCore {
+  private static instance: ListManagerCore;
   private items: { id: string; text: string }[] = [];
+  private storageKey: string = "list-storage";
+  private constructor() {
+    this.loadStorage()
+  }
+  public static getInstance(): ListManagerCore {
+    if (!ListManagerCore.instance) {
+      ListManagerCore.instance = new ListManagerCore();
+    }
+    return ListManagerCore.instance;
+  }
+
+  private saveToStorage(): void {
+    localStorage.setItem(this.storageKey, JSON.stringify(this.items));
+  }
+
+  private loadStorage() {
+    const data = localStorage.getItem(this.storageKey);
+    if (data) {
+      try {
+        this.items = JSON.parse(data);
+      } catch (error) {
+        console.log("localstorage is empty");
+        this.items = [];
+      }
+    }
+  }
 
   addItem(text: string): string {
     const id = uuidv4();
     this.items.push({ id, text });
+    this.saveToStorage()
     return id;
   }
 
   removeItem(id: string): void {
     this.items = this.items.filter((item) => item.id !== id);
+    this.saveToStorage()
   }
 
   getItems() {
@@ -19,5 +48,6 @@ export class ListManagerCore {
 
   clear() {
     this.items = [];
+    this.saveToStorage()
   }
 }

--- a/src/templates/listTemplate.ts
+++ b/src/templates/listTemplate.ts
@@ -5,6 +5,10 @@ export function getListTemplate(config: {
 }): string {
   return `
     <div class="card shadow-sm rounded-4 p-4 border-0" style="max-width: 400px; margin: auto;">
+      <div class="flex">
+         <button id="show-modal-items" class="btn btn-secondary mb-3">Show all Items</button>
+         <button id="clear-list" class="btn btn-secondary mb-3" >Clear List</button>
+      </div>
       <h4 id="list-title" class="mb-3 fw-bold text-primary">To-Do List</h4>
       <div class="input-group mb-3">
         <input 

--- a/src/templates/modalListTemplate.ts
+++ b/src/templates/modalListTemplate.ts
@@ -1,0 +1,19 @@
+export default function getModalTemlate(): string {
+  return `
+<div id="list-modal" class="modal" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">List Items</h5>
+      </div>
+      <div class="modal-body">
+         <ul id="modal-list"></ul>
+      </div>
+      <div class="modal-footer">
+        <button id="close-modal" aria-label="close modal" type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+    `;
+}


### PR DESCRIPTION
This PR adds the following improvements:

- Persist list items in localStorage using Singleton pattern
- Restore list from storage on page reload
- Showed list items in a modal by click on "show all items" button
- Clean the localStorage and internal state by click on "clear list" button

Note: This PR is for review only — no merge intended until approved.

Please review before considering merge